### PR TITLE
Enable VR Support

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -5,7 +5,7 @@
       "repository": "https://gitlab.com/colorglass/vcpkg-colorglass",
       "baseline": "3878737d2cbe7bfc31016d95b54660f87378640c",
       "packages": [
-        "commonlibsse-ng-flatrim"
+        "commonlibsse-ng"
       ]
     }
   ]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,6 +10,6 @@
     "spdlog",
 	"simpleini",
     "xbyak",
-	"commonlibsse-ng-flatrim"
+	"commonlibsse-ng"
   ]
 }


### PR DESCRIPTION
Using Ghidra, I have confirmed that the region of code being hooked in this DLL is 100% identical between SE 1.5.97 and the VR exe, so simply enabling VR support by switching from commonlibsse-ng-flatrim to commonlibsse-ng will work. I cloned down and did a local build and test to confirm this, and everything worked flawlessly.

Note: I also had to make a local change to line 20 of Settings.h as my clone did not like the log statement format as it was. I did not include that change here though because it was not directly related to what I was doing and I am not 100% what the issue is. I suspect it is just a symptom of changes somewhere in the dependency change for the logging though. You may run into the same issue when rebuilding if it pulls updates instead of using an old cache of dependencies from a prior build if I am right.